### PR TITLE
Add version to init

### DIFF
--- a/bitepy/__init__.py
+++ b/bitepy/__init__.py
@@ -8,11 +8,16 @@
 # Licensed under MIT License, see https://opensource.org/license/mit
 ######################################################################
 
+from importlib.metadata import version
+
 from .simulation import Simulation
 from .data import Data
 from .results import Results
 
+
 __all__ = ["Simulation", "Data", "Results"]
+
+__version__ = version("bitepy")
 
 __doc__ = """
 bitepy: A Python Battery Intraday Trading Engine


### PR DESCRIPTION
To enable debugging a bit more easily it makes sense to have the the ability to check:

```
import bitepy
bitepy.__version__
```

This pulls the current version from the `pyproject.toml`. 